### PR TITLE
Fixes for Clang/GCC/Linux builds

### DIFF
--- a/Spatialization/include/JPLSpatial/ErrorReporting.h
+++ b/Spatialization/include/JPLSpatial/ErrorReporting.h
@@ -35,14 +35,14 @@ using TraceFunction = void (*)(const char* message);
 JPL_EXPORT extern TraceFunction Trace;
 
 // Always turn on asserts in Debug mode
-#if defined(_DEBUG) && !defined(JPL_ENABLE_ASSERTS)
+#if !defined(NDEBUG) && !defined(JPL_ENABLE_ASSERTS)
 #define JPL_ENABLE_ASSERTS
 #ifndef JPL_TEST
 #define JPL_ENABLE_ENSURE
 #endif
 #endif
 
-#ifdef JPL_ENABLE_ASSERTS
+#if defined(JPL_ENABLE_ASSERTS) || defined(JPL_ENABLE_ENSURE)
 /// Function called when an assertion fails. This function should return true if a breakpoint needs to be triggered
 using AssertFailedFunction = bool(*)(const char* inExpression, const char* inMessage, const char* inFile, uint inLine);
 JPL_EXPORT extern AssertFailedFunction AssertFailed;
@@ -51,7 +51,9 @@ JPL_EXPORT extern AssertFailedFunction AssertFailed;
 struct AssertLastParam {};
 inline bool AssertFailedParamHelper(const char* inExpression, const char* inFile, uint inLine, AssertLastParam) { return AssertFailed(inExpression, nullptr, inFile, inLine); }
 inline bool AssertFailedParamHelper(const char* inExpression, const char* inFile, uint inLine, const char* inMessage, AssertLastParam) { return AssertFailed(inExpression, inMessage, inFile, inLine); }
+#endif
 
+#ifdef JPL_ENABLE_ASSERTS
 /// Main assert macro, usage: JPL_ASSERT(condition, message) or JPL_ASSERT(condition)
 #define JPL_ASSERT(inExpression, ...)	do { if (!(inExpression) && AssertFailedParamHelper(#inExpression, __FILE__, JPL::uint(__LINE__), ##__VA_ARGS__, JPL::AssertLastParam())) JPL_BREAKPOINT; } while (false)
 

--- a/Spatialization/include/JPLSpatial/Math/Curves.h
+++ b/Spatialization/include/JPLSpatial/Math/Curves.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "../Core.h"
+#include "JPLSpatial/Core.h"
 
 #include <cmath>
 #include <numbers>

--- a/Spatialization/include/JPLSpatial/Math/Curves.h
+++ b/Spatialization/include/JPLSpatial/Math/Curves.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "Core.h"
+#include "../Core.h"
 
 #include <cmath>
 #include <numbers>

--- a/Spatialization/include/JPLSpatial/Services/DirectPathService.h
+++ b/Spatialization/include/JPLSpatial/Services/DirectPathService.h
@@ -19,8 +19,8 @@
 
 #pragma once
 
-#include "../Core.h"
-#include "../DistanceAttenuation.h"
+#include "JPLSpatial/Core.h"
+#include "JPLSpatial/DistanceAttenuation.h"
 
 #include <Jolt/Jolt.h>
 

--- a/Spatialization/include/JPLSpatial/Services/DirectPathService.h
+++ b/Spatialization/include/JPLSpatial/Services/DirectPathService.h
@@ -19,8 +19,8 @@
 
 #pragma once
 
-#include "Core.h"
-#include "DistanceAttenuation.h"
+#include "../Core.h"
+#include "../DistanceAttenuation.h"
 
 #include <Jolt/Jolt.h>
 

--- a/Spatialization/include/JPLSpatial/Services/PanningService.h
+++ b/Spatialization/include/JPLSpatial/Services/PanningService.h
@@ -19,8 +19,8 @@
 
 #pragma once
 
-#include "../VBAP.h"
-#include "../IDType.h"
+#include "JPLSpatial/VBAP.h"
+#include "JPLSpatial/IDType.h"
 
 #include "Jolt/Core/Core.h"
 #include "Jolt/Core/HashCombine.h"

--- a/Spatialization/include/JPLSpatial/VBAP.h
+++ b/Spatialization/include/JPLSpatial/VBAP.h
@@ -56,7 +56,7 @@ namespace JPL
         /// and is not very customizable, e.g. stroing in an int mask vs array)
         static constexpr auto MAX_CHANNELS = 32;
 
-        using ChannelGains = typename std::array<typename float, MAX_CHANNELS>;
+        using ChannelGains = typename std::array<float, MAX_CHANNELS>;
 
         /// Just hiding convenient aliases in traits, no need to ever override these
         static constexpr auto two_pi = std::numbers::pi_v<AngleType> * AngleType(2.0);
@@ -113,8 +113,8 @@ namespace JPL
         // Operators necessary for sorting
         constexpr std::strong_ordering operator<=>(const ChannelAngle& other) const
         {
-            const Traits::AngleType a1 = Angle < Traits::AngleType(0.0) ? Angle + Traits::two_pi : Angle;
-            const Traits::AngleType a2 = other.Angle < Traits::AngleType(0.0) ? other.Angle + Traits::two_pi : other.Angle;
+            const typename Traits::AngleType a1 = Angle < typename Traits::AngleType(0.0) ? Angle + Traits::two_pi : Angle;
+            const typename Traits::AngleType a2 = other.Angle < typename Traits::AngleType(0.0) ? other.Angle + Traits::two_pi : other.Angle;
             if (a1 < a2) return std::strong_ordering::less;
             if (a1 > a2) return std::strong_ordering::greater;
             return std::strong_ordering::equal;
@@ -234,18 +234,18 @@ namespace JPL
         static_assert(std::floating_point<GainType>, "GainType should be floating point.");
         static_assert(std::floating_point<AngleType>, "AngleType should be floating point.");
 
-        using ChannelAngle = typename ChannelAngle<Traits>;
-        using PanUpdateData = typename PanUpdateData<Traits>;
-        using VirtualSource = typename VirtualSource<Traits>;
-        using ChannelGroup = typename ChannelGroup<Traits>;
-        using VBAPData = typename VBAPData<Traits>;
-        using PanSource = typename PanSource<Traits>;
+        using ChannelAngle = ChannelAngle<Traits>;
+        using PanUpdateData = PanUpdateData<Traits>;
+        using VirtualSource = VirtualSource<Traits>;
+        using ChannelGroup = ChannelGroup<Traits>;
+        using VBAPData = VBAPData<Traits>;
+        using PanSource = PanSource<Traits>;
 
         template<class T>
-        using Array = typename Traits::template Array<T>;
-        using ChannelAngleArray = typename Array<ChannelAngle>;
+        using Array = Traits::template Array<T>;
+        using ChannelAngleArray = Array<ChannelAngle>;
 
-        using ChannelGainsRef = typename Traits::ChannelGains&;
+        using ChannelGainsRef = Traits::ChannelGains&;
 
         /// Consts and defaults
         static constexpr uint8 sDeafultQuadrantResolution = 128;
@@ -380,9 +380,9 @@ namespace JPL
             if (skipLFO && channel == EChannel::LFE)
                 return;
 
-            const Traits::AngleType channelAngle = Traits::GetChannelAngle(channel);
+            const typename Traits::AngleType channelAngle = Traits::GetChannelAngle(channel);
 
-            sortedChannelAngles.emplace_back(channelAngle < Traits::AngleType(0.0) ? channelAngle + Traits::two_pi : channelAngle, channelIndex);
+            sortedChannelAngles.emplace_back(channelAngle < typename Traits::AngleType(0.0) ? channelAngle + Traits::two_pi : channelAngle, channelIndex);
         });
 
         std::ranges::sort(sortedChannelAngles);
@@ -418,17 +418,17 @@ namespace JPL
         ChannelAngle<Traits>::GetSortedChannelAngles(channelMap, sourceChannelsSorted);
 
         // Width of a singe source channel in radians
-        const Traits::AngleType channelWidth = Traits::two_pi / static_cast<Traits::AngleType>(numChannels);
-        const Traits::AngleType channelHalfWidth = channelWidth * 0.5f;
+        const typename Traits::AngleType channelWidth = Traits::two_pi / static_cast<Traits::AngleType>(numChannels);
+        const typename Traits::AngleType channelHalfWidth = channelWidth * 0.5f;
 
         // If we don't have center channel, we need to offset channel groups
-        const Traits::AngleType channelAngleOffset = !channelMap.Has(EChannel::FrontCenter)
+        const typename Traits::AngleType channelAngleOffset = !channelMap.Has(EChannel::FrontCenter)
                                         ? 0.5f * channelWidth
                                         : 0.0f;
 
         // Width of a single VS in radians
-        const Traits::AngleType vsBaseWidth = Traits::two_pi / static_cast<Traits::AngleType>(virtualSourcesPerChannel * numChannels);
-        const Traits::AngleType vsHalfWidth = vsBaseWidth * 0.5f;
+        const typename Traits::AngleType vsBaseWidth = Traits::two_pi / static_cast<Traits::AngleType>(virtualSourcesPerChannel * numChannels);
+        const typename Traits::AngleType vsHalfWidth = vsBaseWidth * 0.5f;
 
 
         // 1. Find equal source channel positions for 100% spread
@@ -436,7 +436,7 @@ namespace JPL
         for (uint32 i = 0; i < sourceChannelsSorted.size(); ++i)
         {
             // Assign a centre angle of the next equal section of the source plane
-            const Traits::AngleType channelAngle = channelAngleOffset + channelWidth * i;
+            const typename Traits::AngleType channelAngle = channelAngleOffset + channelWidth * i;
 
             // Create channel group for each source channel
             ChannelGroup<Traits>& channelGroup = ChannelGroups[i];
@@ -453,14 +453,14 @@ namespace JPL
             */
 
             // Find the position of the first virtual source for this channel
-            const Traits::AngleType channelArchStart = channelAngle - channelHalfWidth;
+            const typename Traits::AngleType channelArchStart = channelAngle - channelHalfWidth;
 
-            const Traits::AngleType channelVSStart = channelArchStart + vsHalfWidth;
+            const typename Traits::AngleType channelVSStart = channelArchStart + vsHalfWidth;
             JPL_ASSERT(channelVSStart <= Traits::two_pi);
 
             for (uint32 vi = 0; vi < virtualSourcesPerChannel; ++vi)
             {
-                const Traits::AngleType sourceAngle = channelVSStart + vsBaseWidth * vi;
+                const typename Traits::AngleType sourceAngle = channelVSStart + vsBaseWidth * vi;
                 channelGroup.VirtualSources.emplace_back(VirtualSource<Traits>{ .Angle = sourceAngle });
             }
         }
@@ -485,7 +485,7 @@ namespace JPL
     template<class Traits>
     JPL_INLINE int VBAPanner<Traits>::AngleNormalizedToLUTPosition(AngleType angleNormalised) const
     {
-        const int pos = static_cast<int>((angleNormalised / Traits::two_pi) * mLUTResolution + Traits::AngleType(0.5));
+        const int pos = static_cast<int>((angleNormalised / Traits::two_pi) * mLUTResolution + typename Traits::AngleType(0.5));
         return pos % mLUTResolution;
     }
 
@@ -493,7 +493,7 @@ namespace JPL
     JPL_INLINE int VBAPanner<Traits>::AngleToLUTPosition(AngleType angleInRadians) const
     {
         // Normalize to [0, 2Pi]
-        if (angleInRadians < Traits::AngleType(0.0))
+        if (angleInRadians < typename Traits::AngleType(0.0))
             angleInRadians += Traits::two_pi;
         return AngleNormalizedToLUTPosition(angleInRadians);
     }
@@ -502,7 +502,7 @@ namespace JPL
     JPL_INLINE int VBAPanner<Traits>::CartesianToLUTPosition(float x, float z) const
     {
         // Angle in [-Pi, Pi]
-        const Traits::AngleType angle = std::atan2(x, z);
+        const typename Traits::AngleType angle = std::atan2(x, z);
         return AngleToLUTPosition(angle);
     }
 
@@ -667,7 +667,7 @@ namespace JPL
         JPL_ASSERT(outGains.size() <= mNumChannels);
 
         // Sanity check
-        static_assert(std::is_same_v<decltype(mLUT)::value_type, GainType>);
+        static_assert(std::is_same_v<typename decltype(mLUT)::value_type, GainType>);
 
         const GainType* speakerGain = &mLUT[mNumChannels * lutPosition];
         std::memcpy(outGains.data(), speakerGain, sizeof(GainType) * outGains.size());
@@ -719,7 +719,7 @@ namespace JPL
         std::ranges::for_each(vbap.ChannelGroups, [&getOutGains](const ChannelGroup& channelGroup)
         {
             ChannelGainsRef channelGains = getOutGains(channelGroup.Channel);
-            std::memset(channelGains.data(), 0, channelGains.size() * sizeof(Traits::ChannelGains::value_type));
+            std::memset(channelGains.data(), 0, channelGains.size() * sizeof(typename Traits::ChannelGains::value_type));
         });
 
         // Calculate and accumulate channel panning gains

--- a/Spatialization/src/Spatialization/ErrorReporting.cpp
+++ b/Spatialization/src/Spatialization/ErrorReporting.cpp
@@ -32,7 +32,7 @@ namespace JPL
 
 	TraceFunction Trace = DummyTrace;
 
-#ifdef JPL_ENABLE_ASSERTS
+#if defined(JPL_ENABLE_ASSERTS) || defined(JPL_ENABLE_ENSURE)
 
 	static bool DummyAssertFailed(const char* /*inExpression*/, const char* /*inMessage*/, const char* /*inFile*/, uint /*inLine*/)
 	{


### PR DESCRIPTION
- Fix `ENSURE` requiring `AssertFailed` when it can be defined independent of `ENABLE_ASSERTS`
- Fix `Curves.h` and `DirectPathService.h` including `Core.h` with a non-relative path where other headers in subdirectories of include root do
- VBAP had a number of misapplied and missing `typename` usages which were causing Clang and GCC to complain which have been addressed